### PR TITLE
Add Ctk Quark as dependency

### DIFF
--- a/atk-sc3.quark
+++ b/atk-sc3.quark
@@ -8,10 +8,11 @@
         \schelp: "Intro-to-the-ATK",
            \url: "https://github.com/ambisonictoolkit/atk-sc3",
   \dependencies: [
-              	 "MathLib",
+                 "MathLib",
                  "FileLog",
                  "Hilbert",
                  "wslib",
+                 "Ctk",
                 ],
   \organization: "ATK Community: http://www.ambisonictoolkit.net",
          \since: "2011",


### PR DESCRIPTION
When doing a clean install of atk-sc3 with SC 3.9.2, I found Ctk was also required.

Without it, when trying to create a `FoaDecoderKernel.newListen(1013)` you get:

> Execution warning: Class 'CtkScore' not found
> ERROR: Primitive '_ObjectIsKindOf' failed.
