### PR TITLE
Add Ctk Quarks dependancy

### DIFF
--- a/atk-sc3.quark
+++ b/atk-sc3.quark
@@ -12,6 +12,7 @@
                  "FileLog",
                  "Hilbert",
                  "wslib",
+                 "Ctk"
                 ],
   \organization: "ATK Community: http://www.ambisonictoolkit.net",
          \since: "2011",


### PR DESCRIPTION
In FoaMatrix.sc FoaDecoderKernel-initKernel performs checks for classes CtkScore and CtKBuffer, but this library is not declared as a dependancy in the quarks file.
This commit adds `Ctk` dependancy.