### PR TITLE
HoaNFCtrl: Refactor to removed repeated coefficient calculations.

### DIFF
--- a/Classes/HoaUGen.sc
+++ b/Classes/HoaUGen.sc
@@ -467,19 +467,16 @@ HoaReflect : HoaUGen {
 HoaNFProx : HoaUGen {
 
 	*ar { |in, order = (Hoa.defaultOrder)|
-		var n, hoaOrder;
+		var n = HoaUGen.confirmOrder(in, order);
 
-		n = HoaUGen.confirmOrder(in, order);
-		hoaOrder = n.asHoaOrder;  // instance order
-
-		// NFE
-		^hoaOrder.l.collect({ |l, index|
+		// NFE: collect filtered harmonics, clumped by degree
+		^(n+1).collect({ |l|
 			DegreeProx.ar(
-				in[index],
+				in[l.asHoaDegree.indices],
 				Hoa.refRadius,
 				l
 			)
-		})
+		}).flat // flatten back to full order coefficients
 	}
 }
 
@@ -487,19 +484,16 @@ HoaNFProx : HoaUGen {
 HoaNFDist : HoaUGen {
 
 	*ar { |in, order = (Hoa.defaultOrder)|
-		var n, hoaOrder;
+		var n = HoaUGen.confirmOrder(in, order);
 
-		n = HoaUGen.confirmOrder(in, order);
-		hoaOrder = n.asHoaOrder;  // instance order
-
-		// NFE
-		^hoaOrder.l.collect({ |l, index|
+		// NFE: collect filtered harmonics, clumped by degree
+		^(n+1).collect({ |l|
 			DegreeDist.ar(
-				in[index],
+				in[l.asHoaDegree.indices],
 				Hoa.refRadius,
 				l
 			)
-		})
+		}).flat // flatten back to full order coefficients
 	}
 }
 
@@ -517,20 +511,19 @@ HoaNFDist : HoaUGen {
 HoaNFCtrl : HoaUGen {
 
 	*ar { |in, encRadius, decRadius, order = (Hoa.defaultOrder)|
-		var n, hoaOrder;
+		var n, nfcByDegree;
 
 		n = HoaUGen.confirmOrder(in, order);
-		hoaOrder = n.asHoaOrder;  // instance order
 
-		// NFE
-		^hoaOrder.l.collect({ |l, index|
+		// NFE: collect filtered harmonics, clumped by degree
+		^(n+1).collect({ |l|
 			DegreeCtrl.ar(
-				in[index],
+				in[l.asHoaDegree.indices],
 				encRadius,
 				decRadius,
 				l
 			)
-		})
+		}).flat // flatten back to full order coefficients
 	}
 }
 


### PR DESCRIPTION
The current version will calculate the degree coefficients multiple times for
the same degree, e.g.
```supercollider
HoaOrder(3).l
>> [ 0, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3 ]
```
This will reduce compilation time for larger synthdefs (like decoders) and saves on many operations in the synth graph in the case of NFCtrl which, because the radius is variable, the coefficient calculation function compiles to many UGens. The new design refactors this set of calculations to 1 per degree instead of `2l+1` sets per degree.