### PR TITLE
Foa kernel freeing

### DIFF
--- a/Classes/FoaMatrix.sc
+++ b/Classes/FoaMatrix.sc
@@ -2024,11 +2024,11 @@ FoaDecoderKernel {
 			(kernel.shape[1]).do({ |j|
 				path = kernel[i][j].path;
 				kernel[i][j].free;
-				(
-					"Kernel %, channel % freed.".format(
+				if(path.notNil, {
+					"Decoder kernel %, channel % freed.\n".postf(
 						PathName.new(path).fileName, j
 					)
-				).postln
+				});
 			})
 		})
 	}
@@ -2324,11 +2324,11 @@ FoaEncoderKernel {
 			(kernel.shape[1]).do({ |j|
 				path = kernel[i][j].path;
 				kernel[i][j].free;
-				(
-					"Kernel %, channel % freed.".format(
+				if(path.notNil, {
+					"Encoder kernel %, channel % freed.\n".postf(
 						PathName.new(path).fileName, j
 					)
-				).postln
+				});
 			})
 		})
 	}


### PR DESCRIPTION
If an en/decoder kernel is freed then you call `.free` on the object again, an error was thrown by `PathName` trying to retrieve the `.fileName` from a `nil` path. This fixes that by skipping the post statement if the path is `nil` (A warning is still posted as before that the buffer has already been freed.)

You can test the error by creating an FoaEncoderKernel, then calling `.free` on it twice.