### PR TITLE
Remove Inline Warnings

### DIFF
--- a/Classes/ATK.sc
+++ b/Classes/ATK.sc
@@ -280,7 +280,7 @@ Atk {
 	}
 
 	*downloadSounds { |useSystemLocation = false, action|
-		var tmpPath, url;
+		var tmpPath, url, cmd;
 		var oldFolders, newFolders, diffFolders, pathBeforeRenaiming, pathAfterRenaiming;
 		tmpPath = Platform.defaultTempDir ++ this.hash.asString ++ "sounds.zip";
 		url = this.soundsDownloadUrl;
@@ -311,7 +311,6 @@ Atk {
 			diffFolders = diffFolders.select({|pathSymbol| pathSymbol.asString.contains("sounds")});
 			//continue only if we have a single folder
 			if(diffFolders.size == 1, {
-				var cmd;
 				pathBeforeRenaiming = PathName(diffFolders.first.asString);
 				pathAfterRenaiming = PathName(pathBeforeRenaiming.fullPath.dirname +/+ "sounds");
 				postf("renaming % to %\n", pathBeforeRenaiming.fullPath.withoutTrailingSlash, pathAfterRenaiming.fullPath.withoutTrailingSlash);

--- a/Classes/FoaAudition.sc
+++ b/Classes/FoaAudition.sc
@@ -1157,7 +1157,7 @@ FoaAuditionView {
 
 	update {
 		| who, what ... args |
-
+		var db;
 		if(who == audition, {
 			switch(what,
 				\buffer, {
@@ -1176,8 +1176,7 @@ FoaAuditionView {
 					diffPlayBut.stringColor = args[0].if({ playColor }, { stopColor })
 				},
 				\mul, {
-					var db = args[0].ampdb;
-
+					db = args[0].ampdb;
 					ampSl.value_(ampSpec.unmap(db));
 					ampBx.value_(db)
 				},

--- a/Classes/FoaXformView.sc
+++ b/Classes/FoaXformView.sc
@@ -172,6 +172,8 @@ FoaXformView {
 	// called when selecting a new control from the dropdown menu
 	// rebuild the view with the new controls
 	rebuildControls {
+		var controls;
+
 		// nil this var, it's reset as needed when rebuilt
 		inputMenu = nil;
 
@@ -188,7 +190,6 @@ FoaXformView {
 
 		// don't rebuild controls if muted
 		if(name != \mute, {
-			var controls;
 
 			controls = chain.xFormDict[name].controls.clump(2);
 

--- a/Classes/HoaUGen.sc
+++ b/Classes/HoaUGen.sc
@@ -728,14 +728,14 @@ HoaDecodeDirection : HoaUGen {
 
 DegreeProx {
 	*ar { |in, radius = (AtkHoa.refRadius), degree = 0|
-		var out;
+		var out, coeffDict;
 
 		// degree 0
 		out = in;
 
 		// degree >= 1
 		if(degree > 0, {
-			var coeffDict = NFECoeffs.new(degree).prox(radius, SampleRate.ir);
+			coeffDict = NFECoeffs.new(degree).prox(radius, SampleRate.ir);
 
 			// FOS
 			if(coeffDict.keys.includes(\fos), {
@@ -759,14 +759,14 @@ DegreeProx {
 
 DegreeDist {
 	*ar { |in, radius = (AtkHoa.refRadius), degree = 0|
-		var out;
+		var out, coeffDict;
 
 		// degree 0
 		out = in;
 
 		// degree >= 1
 		if(degree > 0, {
-			var coeffDict = NFECoeffs.new(degree).dist(radius, SampleRate.ir);
+			coeffDict = NFECoeffs.new(degree).dist(radius, SampleRate.ir);
 
 			// FOS
 			if(coeffDict.keys.includes(\fos), {
@@ -790,14 +790,14 @@ DegreeDist {
 
 DegreeCtrl {
 	*ar { |in, encRadius = (AtkHoa.refRadius), decRadius = (AtkHoa.refRadius), degree = 0|
-		var out;
+		var out, coeffDict;
 
 		// degree 0
 		out = in;
 
 		// degree >= 1
 		if(degree > 0, {
-			var coeffDict = NFECoeffs.new(degree).ctrl(encRadius, decRadius, SampleRate.ir);
+			coeffDict = NFECoeffs.new(degree).ctrl(encRadius, decRadius, SampleRate.ir);
 
 			// FOS
 			if(coeffDict.keys.includes(\fos), {

--- a/Classes/extFreqSpectrum.sc
+++ b/Classes/extFreqSpectrum.sc
@@ -51,9 +51,10 @@
 	*hoaProx { |size, radius = (AtkHoa.refRadius), order = (AtkHoa.defaultOrder), sampleRate = nil, speedOfSound = (AtkHoa.speedOfSound)|
 		var hoaOrder = order.asHoaOrder;
 		var freqs, complexCoeffs, magnitudes, phases;
+		var rfftsize;
 
 		if(size.isPowerOfTwo, {  // rfft
-			var rfftsize = (size / 2 + 1).asInteger;
+			rfftsize = (size / 2 + 1).asInteger;
 
 			freqs = rfftsize.rfftFreqs(sampleRate);
 			freqs = freqs.collect({ |freq|  // blt frequency warp
@@ -114,9 +115,10 @@
 	*hoaDist { |size, radius = (AtkHoa.refRadius), order = (AtkHoa.defaultOrder), sampleRate = nil, speedOfSound = (AtkHoa.speedOfSound)|
 		var hoaOrder = order.asHoaOrder;
 		var freqs, complexCoeffs, magnitudes, phases;
+		var rfftsize;
 
 		if(size.isPowerOfTwo, {  // rfft
-			var rfftsize = (size / 2 + 1).asInteger;
+			rfftsize = (size / 2 + 1).asInteger;
 
 			freqs = rfftsize.rfftFreqs(sampleRate);
 			freqs = freqs.collect({ |freq|  // blt frequency warp
@@ -177,9 +179,10 @@
 	*hoaCtrl { |size, encRadius = (AtkHoa.refRadius), decRadius = (AtkHoa.refRadius), order = (AtkHoa.defaultOrder), sampleRate = nil, speedOfSound = (AtkHoa.speedOfSound)|
 		var hoaOrder = order.asHoaOrder;
 		var freqs, complexCoeffs, magnitudes, phases;
+		var rfftsize;
 
 		if(size.isPowerOfTwo, {  // rfft
-			var rfftsize = (size / 2 + 1).asInteger;
+			rfftsize = (size / 2 + 1).asInteger;
 
 			freqs = rfftsize.rfftFreqs(sampleRate);
 			freqs = freqs.collect({ |freq|  // blt frequency warp
@@ -240,9 +243,10 @@
 	*hoaFocl { |size, radius = (AtkHoa.refRadius / 2), order = (AtkHoa.defaultOrder), window = \reg, sampleRate = nil, speedOfSound = (AtkHoa.speedOfSound)|
 		var hoaOrder = order.asHoaOrder;
 		var freqs, magnitudes;
+		var rfftsize;
 
 		if(size.isPowerOfTwo, {  // rfft
-			var rfftsize = (size / 2 + 1).asInteger;
+			rfftsize = (size / 2 + 1).asInteger;
 
 			freqs = rfftsize.rfftFreqs(sampleRate);
 


### PR DESCRIPTION
This patch moves variable declaration out of `if` and `while` statements, so that they can be inlined.

It is generally recommended for developers to keep the interpreter option "Post Inline Warnings" ticked (or: `LanguageConfig.postInlineWarnings = true`.

This fixes #88