### PR TITLE
fix inline error messages

### DIFF
--- a/Classes/ATKAnalyze.sc
+++ b/Classes/ATKAnalyze.sc
@@ -230,7 +230,7 @@ FoaWd : FoaEval {
 FoaWh : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
-		var pReIm, pImRe, uReIm, ir;
+		var pReIm, pImRe, uReIm, ir, magIr;
 		var wp, wu, ws, ia, magI_squared, magIa_squared;
 
 		in = this.checkChans(in);
@@ -287,6 +287,8 @@ FoaWh : FoaEval {
 FoaMagI : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var wp, wu;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -304,8 +306,7 @@ FoaMagI : FoaEval {
 				^(wp * wu).sqrt
 			},
 			{ method == \average }, {
-				var wp, wu;
-				var normFac;
+
 
 				normFac = 2 * size.reciprocal;
 
@@ -570,7 +571,7 @@ FoaMagW : FoaEval {
 FoaMagWa : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
-		var pReIm, uReIm, wp, wu, ws, ia, magIa;
+		var pReIm, uReIm, wp, wu, ws, ia, magIa, normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -617,7 +618,7 @@ FoaMagWa : FoaEval {
 FoaMagWr : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
-		var pReIm, pImRe, uReIm, wp, wu, ws, ir, magIr;
+		var pReIm, pImRe, uReIm, wp, wu, ws, ia, ir, magIr, magI_squared, magIa_squared;
 		var normFac;
 
 		in = this.checkChans(in);
@@ -837,7 +838,7 @@ FoaAlpha : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
 		var pReIm, pImRe, uReIm, ia, magIa, ir, magIr;
-		var wp, wu, ia, magI_squared, magIa_squared;
+		var wp, wu, magI_squared, magIa_squared;
 		var normFac;
 
 		in = this.checkChans(in);
@@ -997,7 +998,7 @@ FoaThetaPhiA : FoaEval {
 		var pReIm, pImRe, uReIm, ia, magIa, ir, magIr, theta, phi;
 		var reg, alpha, gateA;  // gate using -thresh
 
-		var wp, wu, ia, magI_squared, magIa_squared;
+		var wp, wu, magI_squared, magIa_squared;
 		var normFac;
 
 		in = this.checkChans(in);
@@ -1353,6 +1354,7 @@ FoaNa : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
 		var pReIm, uReIm, wp, wu, magI, ia, na;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure

--- a/Classes/ATKAnalyze.sc
+++ b/Classes/ATKAnalyze.sc
@@ -194,6 +194,7 @@ FoaWs : FoaEval {
 FoaWd : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var wp, wu;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -201,7 +202,6 @@ FoaWd : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var wp, wu;
 
 				wp = HilbertW.ar(p, size).squared.sum;
 				wu = HilbertW.ar(u, size).sum({ |item|
@@ -230,6 +230,8 @@ FoaWd : FoaEval {
 FoaWh : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, uReIm, ir;
+		var wp, wu, ws, ia, magI_squared, magIa_squared;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -237,7 +239,6 @@ FoaWh : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, uReIm, wp, wu, ws, ir, magIr;
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;
@@ -257,7 +258,7 @@ FoaWh : FoaEval {
 				^(ws - magIr)
 			},
 			{ method == \average }, {
-				var wp, wu, ws, ia, magI_squared, magIa_squared, magIr;
+
 				var normFac;
 
 				normFac = 2 * size.reciprocal;
@@ -569,6 +570,7 @@ FoaMagW : FoaEval {
 FoaMagWa : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, uReIm, wp, wu, ws, ia, magIa;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -576,7 +578,6 @@ FoaMagWa : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, uReIm, wp, wu, ws, ia, magIa;
 
 				pReIm = HilbertW.ar(p, size);
 				uReIm = HilbertW.ar(u, size);
@@ -595,8 +596,6 @@ FoaMagWa : FoaEval {
 				^(magIa / (ws + DC.ar(FoaEval.reg)))
 			},
 			{ method == \average }, {
-				var wp, wu, ws, ia, magIa;
-				var normFac;
 
 				normFac = 2 * size.reciprocal;
 
@@ -618,6 +617,8 @@ FoaMagWa : FoaEval {
 FoaMagWr : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, uReIm, wp, wu, ws, ir, magIr;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -625,7 +626,6 @@ FoaMagWr : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, uReIm, wp, wu, ws, ir, magIr;
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;
@@ -645,8 +645,6 @@ FoaMagWr : FoaEval {
 				^(magIr / (ws + DC.ar(FoaEval.reg)))
 			},
 			{ method == \average }, {
-				var wp, wu, ws, ia, magI_squared, magIa_squared, magIr;
-				var normFac;
 
 				normFac = 2 * size.reciprocal;
 
@@ -670,6 +668,8 @@ FoaMagWr : FoaEval {
 FoaMagNa : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, uReIm, wp, wu, magI, ia, magIa;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -677,7 +677,6 @@ FoaMagNa : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, uReIm, wp, wu, magI, ia, magIa;
 
 				pReIm = HilbertW.ar(p, size);
 				uReIm = HilbertW.ar(u, size);
@@ -696,8 +695,6 @@ FoaMagNa : FoaEval {
 				^(magIa / (magI + DC.ar(FoaEval.reg)))
 			},
 			{ method == \average }, {
-				var wp, wu, magI, ia, magIa;
-				var normFac;
 
 				normFac = 2 * size.reciprocal;
 
@@ -719,6 +716,9 @@ FoaMagNa : FoaEval {
 FoaMagNr : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, uReIm, wp, wu, magI, ir, magIr;
+		var ia, magI_squared, magIa_squared;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -726,7 +726,6 @@ FoaMagNr : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, uReIm, wp, wu, magI, ir, magIr;
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;
@@ -746,8 +745,6 @@ FoaMagNr : FoaEval {
 				^(magIr / (magI + DC.ar(FoaEval.reg)))
 			},
 			{ method == \average }, {
-				var wp, wu, magI, ia, magI_squared, magIa_squared, magIr;
-				var normFac;
 
 				normFac = 2 * size.reciprocal;
 
@@ -839,6 +836,9 @@ FoaSFIL : FoaEval {
 FoaAlpha : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, uReIm, ia, magIa, ir, magIr;
+		var wp, wu, ia, magI_squared, magIa_squared;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -846,7 +846,7 @@ FoaAlpha : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, uReIm, ia, magIa, ir, magIr;
+
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;
@@ -865,8 +865,7 @@ FoaAlpha : FoaEval {
 				^atan2(magIr, magIa + DC.ar(FoaEval.reg))
 			},
 			{ method == \average }, {
-				var wp, wu, ia, magI_squared, magIa_squared, magIa, magIr;
-				var normFac;
+
 
 				normFac = 2 * size.reciprocal;
 
@@ -891,6 +890,8 @@ FoaAlpha : FoaEval {
 FoaBeta : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var wp, wu, wd, magI;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -898,7 +899,6 @@ FoaBeta : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var wp, wu, wd, magI;
 
 				wp = HilbertW.ar(p, size).squared.sum;
 				wu = HilbertW.ar(u, size).sum({ |item|
@@ -910,8 +910,7 @@ FoaBeta : FoaEval {
 				^atan2(wd, magI + DC.ar(FoaEval.reg))
 			},
 			{ method == \average }, {
-				var wp, wu, wd, magI;
-				var normFac;
+
 
 				normFac = 2 * size.reciprocal;
 
@@ -932,6 +931,8 @@ FoaBeta : FoaEval {
 FoaGamma : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, uReIm, ia, magIa, ir, magIr, cosFac, sinFac;
+		var reg, alpha, gateA, gateR;  // gate using -thresh
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -939,8 +940,7 @@ FoaGamma : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, uReIm, ia, magIa, ir, magIr, cosFac, sinFac;
-				var reg, alpha, gateA, gateR;  // gate using -thresh
+
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;
@@ -994,6 +994,11 @@ FoaGamma : FoaEval {
 FoaThetaPhiA : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, uReIm, ia, magIa, ir, magIr, theta, phi;
+		var reg, alpha, gateA;  // gate using -thresh
+
+		var wp, wu, ia, magI_squared, magIa_squared;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1001,8 +1006,6 @@ FoaThetaPhiA : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, uReIm, ia, magIa, ir, magIr, theta, phi;
-				var reg, alpha, gateA;  // gate using -thresh
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;
@@ -1032,9 +1035,7 @@ FoaThetaPhiA : FoaEval {
 				^Array.with(theta, phi)
 			},
 			{ method == \average }, {
-				var wp, wu, ia, magI_squared, magIa_squared, magIa, magIr, theta, phi;
-				var reg, alpha, gateA;  // gate using -thresh
-				var normFac;
+
 
 				normFac = 2 * size.reciprocal;
 
@@ -1070,6 +1071,8 @@ FoaThetaPhiA : FoaEval {
 FoaThetaPhiR : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, uReIm, ia, magIa, ir, magIr, theta, phi;
+		var reg, alpha, gateR;  // gate using -thresh
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1077,8 +1080,7 @@ FoaThetaPhiR : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, uReIm, ia, magIa, ir, magIr, theta, phi;
-				var reg, alpha, gateR;  // gate using -thresh
+
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;
@@ -1123,6 +1125,8 @@ FoaThetaPhiR : FoaEval {
 FoaIa : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, ia;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1130,7 +1134,6 @@ FoaIa : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, ia;
 
 				pReIm = HilbertW.ar(p, size);
 
@@ -1141,8 +1144,6 @@ FoaIa : FoaEval {
 				^ia
 			},
 			{ method == \average }, {
-				var ia;
-				var normFac;
 
 				normFac = 2 * size.reciprocal;
 
@@ -1159,6 +1160,7 @@ FoaIa : FoaEval {
 FoaIr : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pImRe, ir;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1166,7 +1168,6 @@ FoaIr : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pImRe, ir;
 
 				pImRe = [1, -1] * HilbertW.ar(p, size).reverse;
 
@@ -1189,6 +1190,8 @@ FoaIr : FoaEval {
 FoaAa : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, wp, ia, aa;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1196,7 +1199,6 @@ FoaAa : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, wp, ia, aa;
 
 				pReIm = HilbertW.ar(p, size);
 				wp = pReIm.squared.sum;
@@ -1209,8 +1211,6 @@ FoaAa : FoaEval {
 				^aa
 			},
 			{ method == \average }, {
-				var wp, ia, aa;
-				var normFac;
 
 				normFac = 2 * size.reciprocal;
 
@@ -1229,6 +1229,7 @@ FoaAa : FoaEval {
 FoaAr : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, wp, ir, ar;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1236,7 +1237,6 @@ FoaAr : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, wp, ir, ar;
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;
@@ -1264,6 +1264,8 @@ FoaAr : FoaEval {
 FoaWa : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, uReIm, wp, wu, ws, ia, wa;
+		var normFac;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1271,7 +1273,6 @@ FoaWa : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, uReIm, wp, wu, ws, ia, wa;
 
 				pReIm = HilbertW.ar(p, size);
 				uReIm = HilbertW.ar(u, size);
@@ -1290,8 +1291,6 @@ FoaWa : FoaEval {
 				^wa
 			},
 			{ method == \average }, {
-				var wp, wu, ws, ia, wa;
-				var normFac;
 
 				normFac = 2 * size.reciprocal;
 
@@ -1313,6 +1312,7 @@ FoaWa : FoaEval {
 FoaWr : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, uReIm, wp, wu, ws, ir, wr;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1320,7 +1320,7 @@ FoaWr : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, uReIm, wp, wu, ws, ir, wr;
+
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;
@@ -1352,6 +1352,7 @@ FoaWr : FoaEval {
 FoaNa : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, uReIm, wp, wu, magI, ia, na;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1359,7 +1360,6 @@ FoaNa : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, uReIm, wp, wu, magI, ia, na;
 
 				pReIm = HilbertW.ar(p, size);
 				uReIm = HilbertW.ar(u, size);
@@ -1378,8 +1378,6 @@ FoaNa : FoaEval {
 				^na
 			},
 			{ method == \average }, {
-				var wp, wu, magI, ia, na;
-				var normFac;
 
 				normFac = 2 * size.reciprocal;
 
@@ -1401,6 +1399,7 @@ FoaNa : FoaEval {
 FoaNr : FoaEval {
 	*ar { |in, size = 2048, method = \instant|
 		var p, u;
+		var pReIm, pImRe, uReIm, wp, wu, magI, ir, nr;
 
 		in = this.checkChans(in);
 		p = 2.sqrt * in[0];  // w * 2.sqrt = pressure
@@ -1408,7 +1407,6 @@ FoaNr : FoaEval {
 
 		case(
 			{ method == \instant }, {
-				var pReIm, pImRe, uReIm, wp, wu, magI, ir, nr;
 
 				pReIm = HilbertW.ar(p, size);
 				pImRe = [1, -1] * pReIm.reverse;

--- a/Classes/FoaAudition.sc
+++ b/Classes/FoaAudition.sc
@@ -1157,7 +1157,7 @@ FoaAuditionView {
 
 	update {
 		| who, what ... args |
-		var db;
+		var db, deg;
 		if(who == audition, {
 			switch(what,
 				\buffer, {
@@ -1187,7 +1187,7 @@ FoaAuditionView {
 					diffRttChk.value_(args[0].asBoolean)
 				},
 				\pwAzim, {
-					var deg = args[0].raddeg;
+					deg = args[0].raddeg;
 
 					defer({
 						azimBx.hasFocus !? { // sometimes .hasFocus can return nil (race condition?)

--- a/Classes/HoaLm.sc
+++ b/Classes/HoaLm.sc
@@ -59,6 +59,7 @@ HoaLm {
 
 	*newIndex { |index, ordering = \acn|
 		var l, m;
+		var m0, m1, bool;
 
 		switch(ordering,
 			\acn, {
@@ -67,7 +68,6 @@ HoaLm {
 				^this.new([l, m])
 			},
 			\sid, {
-				var m0, m1, bool;
 
 				l = index.sqrt.floor.asInteger;
 				m0 = (((l + 1).squared - (index + 1)) / 2).floor.asInteger;
@@ -82,7 +82,6 @@ HoaLm {
 				^if(l <= 1, {
 					this.newIndex(index, \sid)
 				}, {
-					var m, m0, m1, bool;
 
 					m0 = -1 * ((index - l.squared) / 2).floor.asInteger;
 					m1 = ((index +1 - l.squared) / 2).floor.asInteger;
@@ -201,6 +200,7 @@ HoaLm {
 
 	normalisation { |scheme = \n3d|
 		var l, m;
+		var dm, mabs;
 
 		#l, m = this.lm;
 
@@ -209,7 +209,7 @@ HoaLm {
 				^sqrt((2 * l) + 1) * this.normalisation(\sn3d)
 			},
 			\sn3d, {
-				var dm, mabs;
+
 
 				dm = (m == 0).asInteger;
 				mabs = m.abs;

--- a/Classes/NFECoeffs.sc
+++ b/Classes/NFECoeffs.sc
@@ -92,15 +92,15 @@ NFECoeffs {
 		var r0 = radius;
 		var mOdd;
 		var alpha;
-		var coeffs, g;
+		var coeffs, g, g0;
 		var coeffsSOS, coeffsFOS;
+		var c1, c2;
 
 		mOdd = this.degree.odd;
 
 		alpha = 2 * sampleRate * r0 / speedOfSound;
 
 		coeffs = numSOS.collect({ |q|
-			var c1, c2;
 
 			c1 = this.reX[q] / alpha;
 			c2 = (this.absX[q] / alpha).squared;
@@ -117,7 +117,6 @@ NFECoeffs {
 
 		// odd degree? - add coeffs for FOS
 		if(mOdd, {
-			var c1;
 
 			c1 = this.reX.last / alpha;
 
@@ -137,7 +136,6 @@ NFECoeffs {
 		g = 1.0;
 
 		(this.numSOS + this.numFOS).do({ |q|
-			var g0;
 
 			g0 = coeffs[q][0];
 			coeffs.put(q,
@@ -168,13 +166,13 @@ NFECoeffs {
 		var alpha;
 		var coeffs, g;
 		var coeffsSOS, coeffsFOS;
+		var c1, c2;
 
 		mOdd = this.degree.odd;
 
 		alpha = 2 * sampleRate * r1 / speedOfSound;
 
 		coeffs = numSOS.collect({ |q|
-			var c1, c2;
 
 			c1 = this.reX[q] / alpha;
 			c2 = (this.absX[q] / alpha).squared;
@@ -191,7 +189,6 @@ NFECoeffs {
 
 		// odd degree? - add coeffs for FOS
 		if(mOdd, {
-			var c1;
 
 			c1 = this.reX.last / alpha;
 

--- a/Classes/extSignal.sc
+++ b/Classes/extSignal.sc
@@ -52,14 +52,16 @@
 		var complexes = FreqSpectrum.hoaDist(size, radius, order, sampleRate, speedOfSound).collect({ |spectrum|
 			spectrum.asComplex
 		});
+		var rfftsize, cosTable;
+		var rcomplex;
 
 		^if(size.isPowerOfTwo, {  // rfft
-			var rfftsize = (size / 2 + 1).asInteger;
-			var cosTable = Signal.rfftCosTable(rfftsize);
+			rfftsize = (size / 2 + 1).asInteger;
+			cosTable = Signal.rfftCosTable(rfftsize);
 
 			// synthesize kernels
 			complexes.collect({ |complex|
-				var rcomplex = complex.real.fftToRfft(complex.imag);
+				rcomplex = complex.real.fftToRfft(complex.imag);
 
 				rcomplex.real.irfft(rcomplex.imag, cosTable)
 			})
@@ -75,14 +77,16 @@
 		var complexes = FreqSpectrum.hoaCtrl(size, encRadius, decRadius, order, sampleRate, speedOfSound).collect({ |spectrum|
 			spectrum.asComplex
 		});
+		var rfftsize, cosTable;
+		var rcomplex;
 
 		^if(size.isPowerOfTwo, {  // rfft
-			var rfftsize = (size / 2 + 1).asInteger;
-			var cosTable = Signal.rfftCosTable(rfftsize);
+			rfftsize = (size / 2 + 1).asInteger;
+			cosTable = Signal.rfftCosTable(rfftsize);
 
 			// synthesize kernels
 			complexes.collect({ |complex|
-				var rcomplex = complex.real.fftToRfft(complex.imag);
+				rcomplex = complex.real.fftToRfft(complex.imag);
 
 				rcomplex.real.irfft(rcomplex.imag, cosTable)
 			})
@@ -98,14 +102,16 @@
 		var complexes = FreqSpectrum.hoaFocl(size, radius, order, window, sampleRate, speedOfSound).collect({ |spectrum|
 			spectrum.linearPhase.asComplex  // linear phase
 		});
+		var rfftsize, cosTable;
+		var rcomplex;
 
 		^if(size.isPowerOfTwo, {  // rfft
-			var rfftsize = (size / 2 + 1).asInteger;
-			var cosTable = Signal.rfftCosTable(rfftsize);
+			rfftsize = (size / 2 + 1).asInteger;
+			cosTable = Signal.rfftCosTable(rfftsize);
 
 			// synthesize kernels
 			complexes.collect({ |complex|
-				var rcomplex = complex.real.fftToRfft(complex.imag);
+				rcomplex = complex.real.fftToRfft(complex.imag);
 
 				rcomplex.real.irfft(rcomplex.imag, cosTable)
 			})
@@ -121,14 +127,16 @@
 		var complexes = FreqSpectrum.hoaMultiBandFocl(size, radius, beamDict, dim, match, numChans, order, window, sampleRate, speedOfSound).collect({ |spectrum|
 			spectrum.linearPhase.asComplex  // linear phase
 		});
+		var rfftsize, cosTable;
+		var rcomplex;
 
 		^if(size.isPowerOfTwo, {  // rfft
-			var rfftsize = (size / 2 + 1).asInteger;
-			var cosTable = Signal.rfftCosTable(rfftsize);
+			rfftsize = (size / 2 + 1).asInteger;
+			cosTable = Signal.rfftCosTable(rfftsize);
 
 			// synthesize kernels
 			complexes.collect({ |complex|
-				var rcomplex = complex.real.fftToRfft(complex.imag);
+				rcomplex = complex.real.fftToRfft(complex.imag);
 
 				rcomplex.real.irfft(rcomplex.imag, cosTable)
 			})

--- a/Classes/extTDesign.sc
+++ b/Classes/extTDesign.sc
@@ -50,7 +50,7 @@
 
 	*newHoa { |numChans, optimize = \energy, order = (AtkHoa.defaultOrder)|
 		var designs, hoaDesign;
-		var numPoints;
+		var numPoints, minT;
 
 		// matched design
 		designs = TDesignLib.getHoaDesigns(optimize, order);
@@ -67,7 +67,7 @@
 
 		// catch no designs
 		hoaDesign ?? {
-			var minT = switch(optimize,
+			minT = switch(optimize,
 				\energy, { 2 * order },      // energy
 				\spreadE, { 2 * order + 1 }  // energy spread
 			);


### PR DESCRIPTION
More of these. It would be *really kind* if all atk-developers could set their own inline warnings to true. 

```supercollider
LanguageConfig.postInlineWarnings_(true)
```

Not doing this makes ATK unusable for those who want to keep the warnings, especially developers (should) have it on by default.

I know that it is stylistically nice to keep variable declarations close by. But over the time, I have noticed that the problem of variables too far from their declaration is usually an indication that methods are becoming too large.

Correcting those variables is a bit tedious …

Thank you! :)

