### PR TITLE
fix typo in FoaEncoderMatrix help file

### DIFF
--- a/HelpSource/Classes/FoaEncoderMatrix.schelp
+++ b/HelpSource/Classes/FoaEncoderMatrix.schelp
@@ -26,7 +26,7 @@ argument:: theta
 Azimuth angle, in radians: pi to -pi
 
 argument:: phi
-Elevation anglein radians: pi/2 to -pi/2
+Elevation angle, in radians: pi/2 to -pi/2
 
 discussion:: This is the classic Ambisonic encoding (panning) function. SuperCollider's inbuilt link::Classes/PanB:: and the Ambisonic Toolkit's link::Classes/FoaPanB:: implement this encoder as a UGen, and provide dynamically changing strong::theta:: and strong::phi:: at the audio and control rates.
 


### PR DESCRIPTION
fixed syntactical error in FoaEncoderMatrix help file: changed "anglein" to "angle, in"